### PR TITLE
Add SWARMSTACK_REPO_VERSION to specify which branch/tag/ref

### DIFF
--- a/ansible/clusters/swarmstack
+++ b/ansible/clusters/swarmstack
@@ -63,6 +63,7 @@ REBOOT_TIMEOUT=180
 # For physical machines, try REBOOT_DELAY=300, and REBOOT_TIMEOUT=600. Physical hosts may take much longer to boot.
 
 SWARMSTACK_REPO=https://github.com/swarmstack/swarmstack
+SWARMSTACK_REPO_VERSION=master
 SWARMSTACK_SRC_DIR=/usr/local/src/swarmstack
 SWARMSTACK_LOCAL_DIR=/usr/local/src/localswarmstack
 

--- a/ansible/playbooks/swarmstack.yml
+++ b/ansible/playbooks/swarmstack.yml
@@ -56,6 +56,7 @@
     git:
       repo: "{{ SWARMSTACK_REPO }}"
       dest: "{{ SWARMSTACK_SRC_DIR }}"
+      version: "{{ SWARMSTACK_REPO_VERSION }}"
     ignore_errors: true
     when: "inventory_hostname == SWARMJOIN"
 


### PR DESCRIPTION
to pull from SWARMSTACK_REPO. Updating both the cluster
configuration file and the swarmstack.yml playbook using
the "version" option in the "git" task "Use git to
download latest swarmstack"